### PR TITLE
better describe IORegistry path to get IOHDACodecAddress

### DIFF
--- a/extras/gui.md
+++ b/extras/gui.md
@@ -55,7 +55,7 @@ So to start, we'll need a couple things:
 * **AudioCodec:**
    * Codec address of Audio controller
    * To find yours:
-      * Check IOReg -> HDEF -> AppleHDAController -> IOHDACodecDevice and see the `IOHDACodecAddress` property
+      * Check IOReg -> HDEF and see the `IOHDACodecAddress` property
       * ex: `0x0`
 
 * **Audio Device:**

--- a/extras/gui.md
+++ b/extras/gui.md
@@ -55,7 +55,7 @@ So to start, we'll need a couple things:
 * **AudioCodec:**
    * Codec address of Audio controller
    * To find yours:
-      * Check IOReg -> HDEF and see the `IOHDACodecAddress` property
+      * Check IOReg -> HDEF -> AppleHDAController -> IOHDACodecDevice and see the `IOHDACodecAddress` property
       * ex: `0x0`
 
 * **Audio Device:**


### PR DESCRIPTION
Just typing the full path out since it is a common error to filter using the keyword "HDEF".  The filter will cause IORegistry to hide child objects of HDEF which make its hard to find IOHDACodecAddress.