### PR TITLE
Add clover updater folder to remove.

### DIFF
--- a/clover-conversion/README.md
+++ b/clover-conversion/README.md
@@ -33,6 +33,7 @@ If folders are empty then delete them as well:
 Users of Clover's Preference Pane will also need to remove that:
 
 * `/Library/PreferencePanes/Clover.prefPane`
+* `/Library/Application\ Support/clover`
 
 # Cleaning the Clover Junk in your hardware
 


### PR DESCRIPTION
Added `/Library/Application\ Support/clover` folder to remove.

I just found out that there is a `Clover Updater` that keeps asking me to update my clover even after I have removed the preference pane and switched to OpenCore 😞 