### PR TITLE
fix typo in amd/zen

### DIFF
--- a/AMD/zen.md
+++ b/AMD/zen.md
@@ -116,7 +116,7 @@ Settings relating to boot.efi patching and firmware fixes, for us we care about 
   * Removes write protection from CR0 register during their execution
 * **ForceExitBootServices**: NO
   * Ensures ExitBootServices calls succeeds even when MemoryMap has changed, don't use unless necessary
-* **ProtectMemoryRegion**: NO
+* **ProtectMemoryRegions**: NO
   * Needed for fixing artefacts and sleep-wake issues, generally only needed on very old firmwares
 * **ProtectSecureBoot**: NO
   * Fixes secureboot keys on MacPro5,1 and Insyde firmwares


### PR DESCRIPTION
There is a typo in amd/zen. In the guide it is described as `ProtectMemoryRegion`, however it should be `ProtectMemoryRegions`.