### PR TITLE
Fix non-clickable 'Setting up the EFI' link

### DIFF
--- a/AMD/fx.md
+++ b/AMD/fx.md
@@ -168,7 +168,7 @@ Needed for spoofing unsupported CPUs like Pentiums and Celerons(AMD CPUs don't r
 
 Blocks certain kexts from loading. Not relevant for us.
 
-### Patch 
+### Patch
 
 This is where the AMD kernel patching magic happens. Please do note that `KernelToPatch` and `MatchOS` from Clover becomes `Kernel` and `MinKernel`/ `MaxKernel` in OpenCore, you can find pre-made patches by [AlGrey](https://amd-osx.com/forum/memberlist.php?mode=viewprofile&u=10918&sid=e0feb8a14a97be482d2fd68dbc268f97)(algrey#9303).
 

--- a/AMD/zen.md
+++ b/AMD/zen.md
@@ -168,7 +168,7 @@ Needed for spoofing unsupported CPUs like Pentiums and Celerons(AMD CPUs don't r
 
 Blocks certain kexts from loading. Not relevant for us.
 
-### Patch 
+### Patch
 
 This is where the AMD kernel patching magic happens. Please do note that `KernelToPatch` and `MatchOS` from Clover becomes `Kernel` and `MinKernel`/ `MaxKernel` in OpenCore, you can find pre-made patches by [AlGrey](https://amd-osx.com/forum/memberlist.php?mode=viewprofile&u=10918&sid=e0feb8a14a97be482d2fd68dbc268f97)(algrey#9303).
 

--- a/clover-conversion/clover-patch.md
+++ b/clover-conversion/clover-patch.md
@@ -1,6 +1,5 @@
 # Converting common Kernel and Kext patches
 
-
 ## Manually converting a patch
 
 When converting a kernel/kext patch into one for OpenCore, you'll need to remember a few things
@@ -52,7 +51,6 @@ So the above patch would become:
 | Mask | Data | |
 | ReplaceMask | Data | |
 
-
 For Min and MaxKernel, we can use the below as for info, so 18G95 has the kernel version `18.7.0` and 18G103 has `18.7.0`(both being the same kernel):
 
 * [macOS Mojave: Release history](https://en.wikipedia.org/wiki/MacOS_Mojave#Release_history)
@@ -61,11 +59,9 @@ For Identifier, you'll either define `kernel` or the kext you want to patch(ie. 
 
 Regarding Limit, Count and Skip, they are set to `0` so they apply to all instances. `Mask` and `ReplaceMask` can be left as blank as Clover doesn't support masking(until very recently but won't be covered here).
 
-
 ## Common patches in OpenCore and co.
 
 Little section mentioning common Kernel and Kexts patches that have been absorbed into OpenCore or other kexts. This list is not complete so any that may have been forgotten can be mentioned by opening a new [issue](https://github.com/khronokernel/OpenCore-Vanilla-Desktop-Guide/issues). Any help is much appreciated
-
 
 ### Kernel Patches
 

--- a/extras/spoof.md
+++ b/extras/spoof.md
@@ -108,7 +108,7 @@ Source: CorpNewt
 
 Depending on your setup, you may find that Windows renders games or applications using an undesired GPU.
 
-Many users only have two GPUs. Nvidia and the Intel HD/UHD IGPU. Since Nvidia no longer works on macOS, they may have the monitor plugged into the motherboards HDMI/DP connection for convenience. As a result, Windows will render all games and applications through the IGPU. You can reroute a specific game or application to a different GPU by going to: Settings > System > Display > Graphics settings 
+Many users only have two GPUs. Nvidia and the Intel HD/UHD IGPU. Since Nvidia no longer works on macOS, they may have the monitor plugged into the motherboards HDMI/DP connection for convenience. As a result, Windows will render all games and applications through the IGPU. You can reroute a specific game or application to a different GPU by going to: Settings > System > Display > Graphics settings
 
 ![Credit to CorpNewt for image](/images/extras/spoof-md/corp-windows.png)
 

--- a/installer-guide/linux-install.md
+++ b/installer-guide/linux-install.md
@@ -116,4 +116,6 @@ In terminal:
       * It will take some time. A LOT if you're using a slow USB (took me about less than 5 minutes with a fast USB2.0 drive).
       ![](/images/installer-guide/linux-install-md/unknown-21.png)
 
-### Now with all this done, head to [Setting up the EFI](/installer-guide/opencore-efi.md) to finish up your work
+### Now with all this done...
+
+... head to [Setting up the EFI](/installer-guide/opencore-efi.md) to finish up your work.

--- a/installer-guide/mac-install.md
+++ b/installer-guide/mac-install.md
@@ -63,4 +63,6 @@ You'll notice that once we open the EFI partition, it's empty. This is where the
 
 ![Empty EFI partition](/images/installer-guide/mac-install-md/base-efi.png)
 
-### Now with all this done, head to [Setting up the EFI](/installer-guide/opencore-efi.md) to finish up your work
+### Now with all this done...
+
+... head to [Setting up the EFI](/installer-guide/opencore-efi.md) to finish up your work.

--- a/installer-guide/winblows-install.md
+++ b/installer-guide/winblows-install.md
@@ -41,4 +41,6 @@ MakeInstall will finish up by installing OpenCore to your USB's EFI System Parti
 
 ![](/images/installer-guide/winblows-install-md/EFI-base.png)
 
-### Now with all this done, head to [Setting up the EFI](/installer-guide/opencore-efi.md) to finish up your work
+### Now with all this done...
+
+... head to [Setting up the EFI](/installer-guide/opencore-efi.md) to finish up your work.


### PR DESCRIPTION
Currently if link is in the header, it's not clickable for `Installer guides` - [Mac](https://dortania.github.io/OpenCore-Desktop-Guide/installer-guide/mac-install.html#now-with-all-this-done-head-to-setting-up-the-efi-to-finish-up-your-work), [Windows](https://dortania.github.io/OpenCore-Desktop-Guide/installer-guide/winblows-install.html#now-with-all-this-done-head-to-setting-up-the-efi-to-finish-up-your-work) and [Linux](https://dortania.github.io/OpenCore-Desktop-Guide/installer-guide/linux-install.html#now-with-all-this-done-head-to-setting-up-the-efi-to-finish-up-your-work) guides.

Same behaviour in Firefox 77.0.1, Chrome 83.0.4103.97 and Safari 13.1.1 (15609.2.9.1.2).

Keep original style and split header to header and text, so link would be clickable again.

Also, few suggested fixed by `markdownlint` were added.

Would be happy to adjust, should you have better way of handling this.

Дякую.