### PR TITLE
Split header and text to make links clickable

### DIFF
--- a/AMD/fx.md
+++ b/AMD/fx.md
@@ -596,4 +596,6 @@ So thanks to the efforts of Ramus, we also have an amazing tool to help verify y
 * EHCI/XHCI Hand-off
 * OS type: Windows 8.1/10 UEFI Mode
 
-# [Post-install](/post-install/README.md)
+# Now with all this done...
+
+... head to [Post-install](/post-install/README.md).

--- a/AMD/zen.md
+++ b/AMD/zen.md
@@ -597,4 +597,6 @@ So thanks to the efforts of Ramus, we also have an amazing tool to help verify y
 * EHCI/XHCI Hand-off
 * OS type: Windows 8.1/10 UEFI Mode
 
-# [Post-install](/post-install/README.md)
+# Now with all this done...
+
+... head to [Post-install](/post-install/README.md).

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -11,7 +11,7 @@
   * [Linux install](/installer-guide/linux-install.md)
 * [Adding The Base OpenCore Files](/installer-guide/opencore-efi.md)
 * [Gathering files](ktext.md)
-* [Getting started with ACPI](/extras/acpi.md)
+* [Getting started with ACPI](https://dortania.github.io/Getting-Started-With-ACPI/)
 
 ## Intel Config.plist
 

--- a/config-HEDT/broadwell-e.md
+++ b/config-HEDT/broadwell-e.md
@@ -587,4 +587,6 @@ So thanks to the efforts of Ramus, we also have an amazing tool to help verify y
 * EHCI/XHCI Hand-off
 * OS type: Windows 8.1/10 UEFI Mode
 
-# [Post-install](/post-install/README.md)
+# Now with all this done...
+
+... head to [Post-install](/post-install/README.md).

--- a/config-HEDT/haswell-e.md
+++ b/config-HEDT/haswell-e.md
@@ -587,4 +587,6 @@ So thanks to the efforts of Ramus, we also have an amazing tool to help verify y
 * EHCI/XHCI Hand-off
 * OS type: Windows 8.1/10 UEFI Mode
 
-# [Post-install](/post-install/README.md)
+# Now with all this done...
+
+... head to [Post-install](/post-install/README.md).

--- a/config-HEDT/skylake-x.md
+++ b/config-HEDT/skylake-x.md
@@ -584,4 +584,6 @@ So thanks to the efforts of Ramus, we also have an amazing tool to help verify y
 * EHCI/XHCI Hand-off
 * OS type: Windows 8.1/10 UEFI Mode
 
-# [Post-install](/post-install/README.md)
+# Now with all this done...
+
+... head to [Post-install](/post-install/README.md).

--- a/config.plist/coffee-lake.md
+++ b/config.plist/coffee-lake.md
@@ -630,4 +630,6 @@ So thanks to the efforts of Ramus, we also have an amazing tool to help verify y
 * OS type: Windows 8.1/10 UEFI Mode
 * DVMT Pre-Allocated(iGPU Memory): 64MB
 
-# [Post-install](/post-install/README.md)
+# Now with all this done...
+
+... head to [Post-install](/post-install/README.md).

--- a/config.plist/comet-lake.md
+++ b/config.plist/comet-lake.md
@@ -620,4 +620,6 @@ So thanks to the efforts of Ramus, we also have an amazing tool to help verify y
 * OS type: Windows 8.1/10 UEFI Mode
 * DVMT Pre-Allocated(iGPU Memory): 64MB
 
-# [Post-install](/post-install/README.md)
+# Now with all this done...
+
+... head to [Post-install](/post-install/README.md).

--- a/config.plist/haswell.md
+++ b/config.plist/haswell.md
@@ -650,4 +650,6 @@ So thanks to the efforts of Ramus, we also have an amazing tool to help verify y
 * OS type: Windows 8.1/10 UEFI Mode
 * DVMT Pre-Allocated(iGPU Memory): 64MB
 
-# [Post-install](/post-install/README.md)
+# Now with all this done...
+
+... head to [Post-install](/post-install/README.md).

--- a/config.plist/ivy-bridge.md
+++ b/config.plist/ivy-bridge.md
@@ -632,4 +632,6 @@ So thanks to the efforts of Ramus, we also have an amazing tool to help verify y
 * OS type: Windows 8.1/10 UEFI Mode
 * DVMT Pre-Allocated(iGPU Memory): 32MB
 
-# [Post-install](/post-install/README.md)
+# Now with all this done...
+
+... head to [Post-install](/post-install/README.md).

--- a/config.plist/kaby-lake.md
+++ b/config.plist/kaby-lake.md
@@ -622,4 +622,6 @@ So thanks to the efforts of Ramus, we also have an amazing tool to help verify y
 * OS type: Windows 8.1/10 UEFI Mode
 * DVMT Pre-Allocated(iGPU Memory): 64MB
 
-# [Post-install](/post-install/README.md)
+# Now with all this done...
+
+... head to [Post-install](/post-install/README.md).

--- a/config.plist/skylake.md
+++ b/config.plist/skylake.md
@@ -620,4 +620,6 @@ So thanks to the efforts of Ramus, we also have an amazing tool to help verify y
 * OS type: Windows 8.1/10 UEFI Mode
 * DVMT Pre-Allocated(iGPU Memory): 64MB
 
-# [Post-install](/post-install/README.md)
+# Now with all this done...
+
+... head to [Post-install](/post-install/README.md).

--- a/installer-guide/opencore-efi.md
+++ b/installer-guide/opencore-efi.md
@@ -48,4 +48,6 @@ Here's what a populated EFI ***can*** look like (yours will be different):
 * Kexts(`.kext`) go in Kexts folder
 * Firmware drivers(`.efi`) go in the Drivers folder
 
-## Now head to [Gathering Files](/ktext.md) to get the needed kexts and firmware drivers
+# Now with all this done...
+
+... head to [Gathering Files](/ktext.md) to get the needed kexts and firmware drivers.

--- a/ktext.md
+++ b/ktext.md
@@ -192,4 +192,6 @@ A quick TL;DR of needed SSDTs(This is source code, you will have to compile them
 | **EC** | [SSDT-EC](https://github.com/acidanthera/OpenCorePkg/blob/master/Docs/AcpiSamples/SSDT-EC.dsl) | [SSDT-EC](https://github.com/acidanthera/OpenCorePkg/blob/master/Docs/AcpiSamples/SSDT-EC.dsl) | [SSDT-EC](https://github.com/acidanthera/OpenCorePkg/blob/master/Docs/AcpiSamples/SSDT-EC.dsl) | [SSDT-EC-USBX](https://github.com/acidanthera/OpenCorePkg/blob/master/Docs/AcpiSamples/SSDT-EC-USBX.dsl) |
 | **AWAC** | N/A | N/A | N/A | [SSDT-AWAC](https://github.com/acidanthera/OpenCorePkg/blob/master/Docs/AcpiSamples/SSDT-AWAC.dsl) |
 
-# Now head [Getting Started With ACPI](https://dortania.github.io/Getting-Started-With-ACPI/)
+# Now with all this done...
+
+... head to [Getting Started With ACPI](https://dortania.github.io/Getting-Started-With-ACPI/).


### PR DESCRIPTION
A follow-up PR to #72.

Split header and text to make links clickable.

Make ACPI link external.

Would be happy to adjust if necessary.