### PR TITLE
Add instruction to open config in ProperTree

### DIFF
--- a/config.plist/README.md
+++ b/config.plist/README.md
@@ -33,7 +33,9 @@ Next, let's open ProperTree and edit our config.plist:
 * `ProperTree.bat`
   * For Windows
 
-Once opened, press **Cmd/Ctrl + Shift + R** and point it at your EFI/OC folder to perform a "Clean Snapshot":
+Once ProperTree is running, open your config.plist by pressing **Cmd/Ctrl + O** and selecting the `config.plist` file on your USB.
+
+After the config is opened, press **Cmd/Ctrl + Shift + R** and point it at your EFI/OC folder to perform a "Clean Snapshot":
 
 * This will remove all the entries from the config.plist and then adds all your SSDTs, Kexts and Firmware drivers to the config
 * **Cmd/Ctrl + R** is another option that will add all your files as well but will leave entries disabled if they were set like that before, useful for when you're troubleshooting but for us not needed right now


### PR DESCRIPTION
Multiple people in the AMD Discord have been confused and have just been running `Clean Snapshot` without opening the sample config (which obviously leaves them without a lot of needed sections)

https://discordapp.com/channels/249992304503291905/263757191608139779/725396805038243871 read from here down to see discussion about why